### PR TITLE
Updated processing XSD Errors like RiseClipse Errors to updated Validation Error.

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -127,6 +127,11 @@ SPDX-License-Identifier: Apache-2.0
             <artifactId>openpojo</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/websocket/SclValidateResponseDecoderTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/websocket/SclValidateResponseDecoderTest.java
@@ -38,7 +38,7 @@ class SclValidateResponseDecoderTest {
     void decode_WhenCalledWithCorrectRequestXML_ThenStringConvertedToObject() {
         var validationMessage = "Some validation error";
         var ruleName = "Rule Name 1";
-        var linenumber = 15;
+        var lineNumber = 15;
         var columnNumber = 34;
 
         var message = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
@@ -46,7 +46,7 @@ class SclValidateResponseDecoderTest {
                 + "<svs:ValidationErrors>"
                 + "<svs:Message>" + validationMessage + "</svs:Message>"
                 + "<svs:RuleName>" + ruleName + "</svs:RuleName>"
-                + "<svs:Linenumber>" + linenumber + "</svs:Linenumber>"
+                + "<svs:LineNumber>" + lineNumber + "</svs:LineNumber>"
                 + "<svs:ColumnNumber>" + columnNumber + "</svs:ColumnNumber>"
                 + "</svs:ValidationErrors>"
                 + "</svs:SclValidateResponse>";
@@ -59,7 +59,7 @@ class SclValidateResponseDecoderTest {
         var validationError = result.getValidationErrorList().get(0);
         assertEquals(validationMessage, validationError.getMessage());
         assertEquals(ruleName, validationError.getRuleName());
-        assertEquals(linenumber, validationError.getLinenumber());
+        assertEquals(lineNumber, validationError.getLineNumber());
         assertEquals(columnNumber, validationError.getColumnNumber());
     }
 

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/websocket/SclValidateResponseDecoderTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/websocket/SclValidateResponseDecoderTest.java
@@ -37,16 +37,30 @@ class SclValidateResponseDecoderTest {
     @Test
     void decode_WhenCalledWithCorrectRequestXML_ThenStringConvertedToObject() {
         var validationMessage = "Some validation error";
+        var ruleName = "Rule Name 1";
+        var linenumber = 15;
+        var columnNumber = 34;
+
         var message = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
                 + "<svs:SclValidateResponse xmlns:svs=\"" + SCL_VALIDATOR_SERVICE_V1_NS_URI + "\">"
-                + "<svs:ValidationErrors><svs:Message>" + validationMessage + "</svs:Message></svs:ValidationErrors>"
+                + "<svs:ValidationErrors>"
+                + "<svs:Message>" + validationMessage + "</svs:Message>"
+                + "<svs:RuleName>" + ruleName + "</svs:RuleName>"
+                + "<svs:Linenumber>" + linenumber + "</svs:Linenumber>"
+                + "<svs:ColumnNumber>" + columnNumber + "</svs:ColumnNumber>"
+                + "</svs:ValidationErrors>"
                 + "</svs:SclValidateResponse>";
 
         var result = decoder.decode(message);
 
         assertNotNull(result);
         assertEquals(1, result.getValidationErrorList().size());
-        assertEquals(validationMessage, result.getValidationErrorList().get(0).getMessage());
+
+        var validationError = result.getValidationErrorList().get(0);
+        assertEquals(validationMessage, validationError.getMessage());
+        assertEquals(ruleName, validationError.getRuleName());
+        assertEquals(linenumber, validationError.getLinenumber());
+        assertEquals(columnNumber, validationError.getColumnNumber());
     }
 
     @Test

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/websocket/SclValidateResponseEncoderTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/websocket/SclValidateResponseEncoderTest.java
@@ -29,7 +29,7 @@ class SclValidateResponseEncoderTest {
     void encode_WhenCalledWithRequest_ThenRequestConvertedToString() {
         var validationMessage = "Some Validation Message";
         var ruleName = "Rule Name 1";
-        var linenumber = 15;
+        var lineNumber = 15;
         var columnNumber = 34;
 
         var request = new SclValidateResponse();
@@ -37,7 +37,7 @@ class SclValidateResponseEncoderTest {
         var validationError = new ValidationError();
         validationError.setMessage(validationMessage);
         validationError.setRuleName(ruleName);
-        validationError.setLinenumber(linenumber);
+        validationError.setLineNumber(lineNumber);
         validationError.setColumnNumber(columnNumber);
         request.getValidationErrorList().add(validationError);
 
@@ -48,7 +48,7 @@ class SclValidateResponseEncoderTest {
                 "<svs:ValidationErrors>" +
                 "<svs:Message>" + validationMessage + "</svs:Message>" +
                 "<svs:RuleName>" + ruleName + "</svs:RuleName>" +
-                "<svs:Linenumber>" + linenumber + "</svs:Linenumber>" +
+                "<svs:LineNumber>" + lineNumber + "</svs:LineNumber>" +
                 "<svs:ColumnNumber>" + columnNumber + "</svs:ColumnNumber>" +
                 "</svs:ValidationErrors>" +
                 "</svs:SclValidateResponse>";

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/websocket/SclValidateResponseEncoderTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/websocket/SclValidateResponseEncoderTest.java
@@ -30,6 +30,7 @@ class SclValidateResponseEncoderTest {
         var validationMessage = "Some Validation Message";
         var ruleName = "Rule Name 1";
         var linenumber = 15;
+        var columnNumber = 34;
 
         var request = new SclValidateResponse();
         request.setValidationErrorList(new ArrayList<>());
@@ -37,6 +38,7 @@ class SclValidateResponseEncoderTest {
         validationError.setMessage(validationMessage);
         validationError.setRuleName(ruleName);
         validationError.setLinenumber(linenumber);
+        validationError.setColumnNumber(columnNumber);
         request.getValidationErrorList().add(validationError);
 
         var result = encoder.encode(request);
@@ -47,6 +49,7 @@ class SclValidateResponseEncoderTest {
                 "<svs:Message>" + validationMessage + "</svs:Message>" +
                 "<svs:RuleName>" + ruleName + "</svs:RuleName>" +
                 "<svs:Linenumber>" + linenumber + "</svs:Linenumber>" +
+                "<svs:ColumnNumber>" + columnNumber + "</svs:ColumnNumber>" +
                 "</svs:ValidationErrors>" +
                 "</svs:SclValidateResponse>";
         assertNotNull(result);

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@ SPDX-License-Identifier: Apache-2.0
 
             <dependency>
                 <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>

--- a/riseclipse/riseclipse-p2-to-m2/pom.xml
+++ b/riseclipse/riseclipse-p2-to-m2/pom.xml
@@ -32,6 +32,7 @@ SPDX-License-Identifier: Apache-2.0
         <version>2.7.4</version>
         <configuration>
           <work>${project.build.directory}/maven/tmp/cbi</work>
+          <executionEnvironment>JavaSE-17</executionEnvironment>
 
           <repositories>
             <repository>

--- a/riseclipse/validator-riseclipse/src/main/java/org/lfenergy/compas/scl/validator/impl/OclFileLoader.java
+++ b/riseclipse/validator-riseclipse/src/main/java/org/lfenergy/compas/scl/validator/impl/OclFileLoader.java
@@ -40,7 +40,7 @@ public class OclFileLoader {
         // Create an OCL that creates a ResourceSet using the minimal EPackage.Registry
         this.ocl = OCL.newInstance(registry);
 
-        // First make sure the directory for temporary file exists.
+        // First make sure the directory for temporary file exists and if not will be created.
         var tempDirectory = tempDirectoryPath.toFile();
         if (!tempDirectory.exists() && !tempDirectory.mkdirs()) {
             throw new SclValidatorException(CREATE_OCL_TEMP_DIR_FAILED, "Unable to create temporary directory");
@@ -54,8 +54,7 @@ public class OclFileLoader {
     }
 
     public void loadOCLDocuments() {
-        oclFiles.stream()
-                .forEach(this::addOCLDocument);
+        oclFiles.forEach(this::addOCLDocument);
     }
 
     public void addOCLDocument(URI oclUri) {

--- a/riseclipse/validator-riseclipse/src/main/java/org/lfenergy/compas/scl/validator/impl/SclRiseClipseValidator.java
+++ b/riseclipse/validator-riseclipse/src/main/java/org/lfenergy/compas/scl/validator/impl/SclRiseClipseValidator.java
@@ -81,10 +81,10 @@ public class SclRiseClipseValidator implements SclValidator {
             if (validationError.isPresent()) {
                 validationErrors.add(validationError.get());
                 if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("SCL Validation Error '{}' from Rule '{}' (Linenumber {})",
+                    LOGGER.debug("SCL Validation Error '{}' from Rule '{}' (Line number {})",
                             validationError.get().getMessage(),
                             validationError.get().getRuleName(),
-                            validationError.get().getLinenumber());
+                            validationError.get().getLineNumber());
                 }
             }
 

--- a/riseclipse/validator-riseclipse/src/main/java/org/lfenergy/compas/scl/validator/util/MessageUtil.java
+++ b/riseclipse/validator-riseclipse/src/main/java/org/lfenergy/compas/scl/validator/util/MessageUtil.java
@@ -24,16 +24,16 @@ public class MessageUtil {
         var validationError = new ValidationError();
         var messageParts = message.split(";");
         if (messageParts.length == 5) {
-            // The expected number of parts is found, the message and rule are set as-is, the linenumber is converted
-            // to a Long value,
+            // The expected number of parts is found, the message and rule are set as-is, the line number
+            // is converted to a Integer value,
             validationError.setRuleName(messageParts[1]);
             validationError.setMessage(messageParts[4]);
 
             try {
-                validationError.setLinenumber(Integer.parseInt(messageParts[3]));
+                validationError.setLineNumber(Integer.parseInt(messageParts[3]));
             } catch (NumberFormatException exp) {
-                validationError.setLinenumber(-1);
-                LOGGER.debug("Invalid linenumber '{}' found", messageParts[3], exp);
+                validationError.setLineNumber(-1);
+                LOGGER.debug("Invalid line number '{}' found", messageParts[3], exp);
             }
         } else if (messageParts.length == 2) {
             // It seems like an old message that starts with 'ERROR;', so only set the second part as Message

--- a/riseclipse/validator-riseclipse/src/main/java/org/lfenergy/compas/scl/validator/util/MessageUtil.java
+++ b/riseclipse/validator-riseclipse/src/main/java/org/lfenergy/compas/scl/validator/util/MessageUtil.java
@@ -30,7 +30,7 @@ public class MessageUtil {
             validationError.setMessage(messageParts[4]);
 
             try {
-                validationError.setLinenumber(Long.parseLong(messageParts[3]));
+                validationError.setLinenumber(Integer.parseInt(messageParts[3]));
             } catch (NumberFormatException exp) {
                 validationError.setLinenumber(-1);
                 LOGGER.debug("Invalid linenumber '{}' found", messageParts[3], exp);

--- a/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/impl/OclFileLoaderTest.java
+++ b/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/impl/OclFileLoaderTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.lfenergy.compas.scl.validator.exception.SclValidatorErrorCode.NO_URI_PASSED;
+import static org.lfenergy.compas.scl.validator.exception.SclValidatorErrorCode.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,6 +44,38 @@ class OclFileLoaderTest {
                 .filter(path -> path.toString().contains(File.separator + "allConstraints"))
                 .findFirst()
                 .orElseThrow();
+    }
+
+    @Test
+    void constructor_WhenCalledWithUnCreatableDirectory_ThenExceptionThrown() {
+        var unCreatablePath = Path.of("/some-directory");
+        if (isWindows()) {
+            unCreatablePath = Path.of("C:/Windows/some-directory");
+        }
+
+        var directoryPath = unCreatablePath;
+        var exception = assertThrows(SclValidatorException.class,
+                () -> new OclFileLoader(directoryPath, List.of()));
+
+        assertEquals(CREATE_OCL_TEMP_DIR_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    void constructor_WhenCalledWithUnCreatableTempFile_ThenExceptionThrown() {
+        var unWritablePath = Path.of("/");
+        if (isWindows()) {
+            unWritablePath = Path.of("C:/Windows");
+        }
+
+        var directoryPath = unWritablePath;
+        var exception = assertThrows(SclValidatorException.class,
+                () -> new OclFileLoader(directoryPath, List.of()));
+
+        assertEquals(CREATE_OCL_TEMP_FILES_FAILED, exception.getErrorCode());
+    }
+
+    private boolean isWindows() {
+        return System.getProperty("os.name").contains("win");
     }
 
     @Test

--- a/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/impl/OclFileLoaderTest.java
+++ b/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/impl/OclFileLoaderTest.java
@@ -53,9 +53,9 @@ class OclFileLoaderTest {
             unCreatablePath = Path.of("C:/Windows/some-directory");
         }
 
+        List<URI> fileList = List.of();
         var directoryPath = unCreatablePath;
-        var exception = assertThrows(SclValidatorException.class,
-                () -> new OclFileLoader(directoryPath, List.of()));
+        var exception = assertThrows(SclValidatorException.class, () -> new OclFileLoader(directoryPath, fileList));
 
         assertEquals(CREATE_OCL_TEMP_DIR_FAILED, exception.getErrorCode());
     }
@@ -67,9 +67,9 @@ class OclFileLoaderTest {
             unWritablePath = Path.of("C:/Windows");
         }
 
+        List<URI> fileList = List.of();
         var directoryPath = unWritablePath;
-        var exception = assertThrows(SclValidatorException.class,
-                () -> new OclFileLoader(directoryPath, List.of()));
+        var exception = assertThrows(SclValidatorException.class, () -> new OclFileLoader(directoryPath, fileList));
 
         assertEquals(CREATE_OCL_TEMP_FILES_FAILED, exception.getErrorCode());
     }

--- a/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/impl/SclRiseClipseValidatorTest.java
+++ b/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/impl/SclRiseClipseValidatorTest.java
@@ -37,6 +37,6 @@ class SclRiseClipseValidatorTest {
         var firstMessage = result.get(0);
         assertNotNull(firstMessage.getRuleName());
         assertNotNull(firstMessage.getMessage());
-        assertTrue(firstMessage.getLinenumber() > 0);
+        assertTrue(firstMessage.getLineNumber() > 0);
     }
 }

--- a/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/util/MessageUtilTest.java
+++ b/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/util/MessageUtilTest.java
@@ -41,7 +41,7 @@ class MessageUtilTest {
 
         var validationError = result.get();
         assertNull(validationError.getRuleName());
-        assertNull(validationError.getLinenumber());
+        assertNull(validationError.getLineNumber());
         assertNull(validationError.getColumnNumber());
         assertEquals(message, validationError.getMessage());
     }
@@ -57,7 +57,7 @@ class MessageUtilTest {
 
         var validationError = result.get();
         assertNull(validationError.getRuleName());
-        assertNull(validationError.getLinenumber());
+        assertNull(validationError.getLineNumber());
         assertNull(validationError.getColumnNumber());
         assertEquals(message, validationError.getMessage());
     }
@@ -66,22 +66,22 @@ class MessageUtilTest {
     void createValidationError_WhenCalledWithCorrectMessage_ThenConvertValidationErrorReturned() {
         var message = "AnyLN (lnType=LN2) does not refer an existing LNodeType in DataTypeTemplates section";
         var ruleName = "OCL/SemanticConstraints/AnyLN_RefersToLNodeType";
-        var linenumber = 9;
+        var lineNumber = 9;
 
-        var result = createValidationError("ERROR;" + ruleName + ";scl-file.scd;" + linenumber + ";" + message);
+        var result = createValidationError("ERROR;" + ruleName + ";scl-file.scd;" + lineNumber + ";" + message);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
 
         var validationError = result.get();
         assertEquals(ruleName, validationError.getRuleName());
-        assertEquals(linenumber, validationError.getLinenumber());
+        assertEquals(lineNumber, validationError.getLineNumber());
         assertNull(validationError.getColumnNumber());
         assertEquals(message, validationError.getMessage());
     }
 
     @Test
-    void createValidationError_WhenCalledWithInvalidLinenumber_ThenNegativeLinenumberReturned() {
+    void createValidationError_WhenCalledWithInvalidLineNumber_ThenNegativeLineNumberReturned() {
         var message = "AnyLN (lnType=LN2) does not refer an existing LNodeType in DataTypeTemplates section";
         var ruleName = "OCL/SemanticConstraints/AnyLN_RefersToLNodeType";
 
@@ -92,7 +92,7 @@ class MessageUtilTest {
 
         var validationError = result.get();
         assertEquals(ruleName, validationError.getRuleName());
-        assertEquals(-1, validationError.getLinenumber());
+        assertEquals(-1, validationError.getLineNumber());
         assertNull(validationError.getColumnNumber());
         assertEquals(message, validationError.getMessage());
     }

--- a/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/util/MessageUtilTest.java
+++ b/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/util/MessageUtilTest.java
@@ -64,7 +64,7 @@ class MessageUtilTest {
     void createValidationError_WhenCalledWithCorrectMessage_ThenConvertValidationErrorReturned() {
         var message = "AnyLN (lnType=LN2) does not refer an existing LNodeType in DataTypeTemplates section";
         var ruleName = "OCL/SemanticConstraints/AnyLN_RefersToLNodeType";
-        var linenumber = (long) 9;
+        var linenumber = 9;
 
         var result = createValidationError("ERROR;" + ruleName + ";scl-file.scd;" + linenumber + ";" + message);
 

--- a/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/util/MessageUtilTest.java
+++ b/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/util/MessageUtilTest.java
@@ -41,7 +41,8 @@ class MessageUtilTest {
 
         var validationError = result.get();
         assertNull(validationError.getRuleName());
-        assertEquals(0, validationError.getLinenumber());
+        assertNull(validationError.getLinenumber());
+        assertNull(validationError.getColumnNumber());
         assertEquals(message, validationError.getMessage());
     }
 
@@ -56,7 +57,8 @@ class MessageUtilTest {
 
         var validationError = result.get();
         assertNull(validationError.getRuleName());
-        assertEquals(0, validationError.getLinenumber());
+        assertNull(validationError.getLinenumber());
+        assertNull(validationError.getColumnNumber());
         assertEquals(message, validationError.getMessage());
     }
 
@@ -74,6 +76,7 @@ class MessageUtilTest {
         var validationError = result.get();
         assertEquals(ruleName, validationError.getRuleName());
         assertEquals(linenumber, validationError.getLinenumber());
+        assertNull(validationError.getColumnNumber());
         assertEquals(message, validationError.getMessage());
     }
 
@@ -90,6 +93,7 @@ class MessageUtilTest {
         var validationError = result.get();
         assertEquals(ruleName, validationError.getRuleName());
         assertEquals(-1, validationError.getLinenumber());
+        assertNull(validationError.getColumnNumber());
         assertEquals(message, validationError.getMessage());
     }
 }

--- a/service/src/main/java/org/lfenergy/compas/scl/validator/common/NsdocFinder.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/validator/common/NsdocFinder.java
@@ -36,14 +36,12 @@ public class NsdocFinder {
         File directory = new File(directoryName);
         if (directory.exists() && directory.isDirectory()) {
             var files = directory.listFiles();
-            if (files != null) {
-                return Arrays.stream(files)
-                        .filter(File::isFile)
-                        .filter(file -> file.getName().endsWith(".nsdoc"))
-                        .map(this::convertToNsdocFile)
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toMap(NsdocFile::getId, Function.identity()));
-            }
+            return Arrays.stream(files)
+                    .filter(File::isFile)
+                    .filter(file -> file.getName().endsWith(".nsdoc"))
+                    .map(this::convertToNsdocFile)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toMap(NsdocFile::getId, Function.identity()));
         }
         return Collections.emptyMap();
     }

--- a/service/src/test/java/org/lfenergy/compas/scl/validator/common/NsdocFinderTest.java
+++ b/service/src/test/java/org/lfenergy/compas/scl/validator/common/NsdocFinderTest.java
@@ -35,7 +35,16 @@ class NsdocFinderTest {
 
     @Test
     void getNsdocFiles_WhenCalledWithNonExistingDirectory_ThenNoEntriesReturned() {
-        finder = new NsdocFinder("./src/text/data/non-existing");
+        finder = new NsdocFinder("./src/test/data/non-existing");
+        var files = finder.getNsdocFiles();
+
+        assertNotNull(files);
+        assertEquals(0, files.size());
+    }
+
+    @Test
+    void getNsdocFiles_WhenCalledWithFileAndNotDirectory_ThenNoEntriesReturned() {
+        finder = new NsdocFinder("./src/test/data/nsdoc/invalid.doc");
         var files = finder.getNsdocFiles();
 
         assertNotNull(files);

--- a/validator/src/main/java/org/lfenergy/compas/scl/validator/model/ValidationError.java
+++ b/validator/src/main/java/org/lfenergy/compas/scl/validator/model/ValidationError.java
@@ -31,13 +31,13 @@ public class ValidationError {
             example = "9")
     @XmlElement(name = "Linenumber",
             namespace = SCL_VALIDATOR_SERVICE_V1_NS_URI)
-    private long linenumber;
+    private Integer linenumber;
 
     @Schema(description = "The column number on the linenumber in the SCL file where the validation error occurred",
             example = "14")
     @XmlElement(name = "ColumnNumber",
             namespace = SCL_VALIDATOR_SERVICE_V1_NS_URI)
-    private long columnNumber;
+    private Integer columnNumber;
 
     public String getMessage() {
         return message;
@@ -55,19 +55,19 @@ public class ValidationError {
         this.ruleName = ruleName;
     }
 
-    public long getLinenumber() {
+    public Integer getLinenumber() {
         return linenumber;
     }
 
-    public void setLinenumber(long linenumber) {
+    public void setLinenumber(Integer linenumber) {
         this.linenumber = linenumber;
     }
 
-    public long getColumnNumber() {
+    public Integer getColumnNumber() {
         return columnNumber;
     }
 
-    public void setColumnNumber(long columnNumber) {
+    public void setColumnNumber(Integer columnNumber) {
         this.columnNumber = columnNumber;
     }
 }

--- a/validator/src/main/java/org/lfenergy/compas/scl/validator/model/ValidationError.java
+++ b/validator/src/main/java/org/lfenergy/compas/scl/validator/model/ValidationError.java
@@ -27,13 +27,13 @@ public class ValidationError {
             namespace = SCL_VALIDATOR_SERVICE_V1_NS_URI)
     private String ruleName;
 
-    @Schema(description = "The linenumber in the SCL file where the validation error occurred",
+    @Schema(description = "The line number in the SCL file where the validation error occurred",
             example = "9")
-    @XmlElement(name = "Linenumber",
+    @XmlElement(name = "LineNumber",
             namespace = SCL_VALIDATOR_SERVICE_V1_NS_URI)
-    private Integer linenumber;
+    private Integer lineNumber;
 
-    @Schema(description = "The column number on the linenumber in the SCL file where the validation error occurred",
+    @Schema(description = "The column number on the line number in the SCL file where the validation error occurred",
             example = "14")
     @XmlElement(name = "ColumnNumber",
             namespace = SCL_VALIDATOR_SERVICE_V1_NS_URI)
@@ -55,12 +55,12 @@ public class ValidationError {
         this.ruleName = ruleName;
     }
 
-    public Integer getLinenumber() {
-        return linenumber;
+    public Integer getLineNumber() {
+        return lineNumber;
     }
 
-    public void setLinenumber(Integer linenumber) {
-        this.linenumber = linenumber;
+    public void setLineNumber(Integer lineNumber) {
+        this.lineNumber = lineNumber;
     }
 
     public Integer getColumnNumber() {

--- a/validator/src/main/java/org/lfenergy/compas/scl/validator/model/ValidationError.java
+++ b/validator/src/main/java/org/lfenergy/compas/scl/validator/model/ValidationError.java
@@ -33,6 +33,12 @@ public class ValidationError {
             namespace = SCL_VALIDATOR_SERVICE_V1_NS_URI)
     private long linenumber;
 
+    @Schema(description = "The column number on the linenumber in the SCL file where the validation error occurred",
+            example = "14")
+    @XmlElement(name = "ColumnNumber",
+            namespace = SCL_VALIDATOR_SERVICE_V1_NS_URI)
+    private long columnNumber;
+
     public String getMessage() {
         return message;
     }
@@ -55,5 +61,13 @@ public class ValidationError {
 
     public void setLinenumber(long linenumber) {
         this.linenumber = linenumber;
+    }
+
+    public long getColumnNumber() {
+        return columnNumber;
+    }
+
+    public void setColumnNumber(long columnNumber) {
+        this.columnNumber = columnNumber;
     }
 }

--- a/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandler.java
+++ b/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandler.java
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2022 Alliander N.V.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.lfenergy.compas.scl.validator.xsd;
+
+import org.lfenergy.compas.scl.validator.model.ValidationError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXParseException;
+
+import java.util.List;
+
+public class XSDErrorHandler implements ErrorHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(XSDErrorHandler.class);
+
+    private List<ValidationError> errorList;
+
+    public XSDErrorHandler(List<ValidationError> errorList) {
+        this.errorList = errorList;
+    }
+
+    @Override
+    public void warning(SAXParseException exception) {
+        var validationError = createValidationError(exception);
+        errorList.add(validationError);
+
+        LOGGER.debug("XSD Validation - warning: '{}' (Linenumber {}, Column number {})",
+                validationError.getMessage(),
+                validationError.getLinenumber(),
+                validationError.getColumnNumber());
+    }
+
+    @Override
+    public void error(SAXParseException exception) {
+        var validationError = createValidationError(exception);
+        errorList.add(validationError);
+
+        LOGGER.debug("XSD Validation - error: '{}' (Linenumber {}, Column number {})",
+                validationError.getMessage(),
+                validationError.getLinenumber(),
+                validationError.getColumnNumber());
+    }
+
+    @Override
+    public void fatalError(SAXParseException exception) {
+        var validationError = createValidationError(exception);
+        errorList.add(validationError);
+
+        LOGGER.debug("XSD Validation - fatal error, stopping: '{}' (Linenumber {}, Column number {})",
+                validationError.getMessage(),
+                validationError.getLinenumber(),
+                validationError.getColumnNumber());
+    }
+
+    private ValidationError createValidationError(SAXParseException exception) {
+        var validationError = new ValidationError();
+        validationError.setMessage(exception.getMessage());
+        validationError.setRuleName("XSD validation");
+        validationError.setLinenumber(exception.getLineNumber());
+        validationError.setColumnNumber(exception.getColumnNumber());
+        return validationError;
+    }
+}

--- a/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandler.java
+++ b/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandler.java
@@ -28,9 +28,9 @@ public class XSDErrorHandler implements ErrorHandler {
         var validationError = createValidationError(exception);
         errorList.add(validationError);
 
-        LOGGER.debug("XSD Validation - warning: '{}' (Linenumber {}, Column number {})",
+        LOGGER.debug("XSD Validation - warning: '{}' (Line number {}, Column number {})",
                 validationError.getMessage(),
-                validationError.getLinenumber(),
+                validationError.getLineNumber(),
                 validationError.getColumnNumber());
     }
 
@@ -39,9 +39,9 @@ public class XSDErrorHandler implements ErrorHandler {
         var validationError = createValidationError(exception);
         errorList.add(validationError);
 
-        LOGGER.debug("XSD Validation - error: '{}' (Linenumber {}, Column number {})",
+        LOGGER.debug("XSD Validation - error: '{}' (Line number {}, Column number {})",
                 validationError.getMessage(),
-                validationError.getLinenumber(),
+                validationError.getLineNumber(),
                 validationError.getColumnNumber());
     }
 
@@ -50,9 +50,9 @@ public class XSDErrorHandler implements ErrorHandler {
         var validationError = createValidationError(exception);
         errorList.add(validationError);
 
-        LOGGER.debug("XSD Validation - fatal error, stopping: '{}' (Linenumber {}, Column number {})",
+        LOGGER.debug("XSD Validation - fatal error, stopping: '{}' (Line number {}, Column number {})",
                 validationError.getMessage(),
-                validationError.getLinenumber(),
+                validationError.getLineNumber(),
                 validationError.getColumnNumber());
     }
 
@@ -61,7 +61,7 @@ public class XSDErrorHandler implements ErrorHandler {
         var xsdMessage = exception.getMessage();
         validationError.setMessage(getMessage(xsdMessage));
         validationError.setRuleName(getRuleName(xsdMessage));
-        validationError.setLinenumber(exception.getLineNumber());
+        validationError.setLineNumber(exception.getLineNumber());
         validationError.setColumnNumber(exception.getColumnNumber());
         return validationError;
     }

--- a/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandler.java
+++ b/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandler.java
@@ -14,6 +14,9 @@ import java.util.List;
 public class XSDErrorHandler implements ErrorHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(XSDErrorHandler.class);
 
+    public static final String DEFAULT_PREFIX = "XSD/";
+    public static final String DEFAULT_RULE_NAME = DEFAULT_PREFIX + "general";
+
     private List<ValidationError> errorList;
 
     public XSDErrorHandler(List<ValidationError> errorList) {
@@ -55,10 +58,39 @@ public class XSDErrorHandler implements ErrorHandler {
 
     private ValidationError createValidationError(SAXParseException exception) {
         var validationError = new ValidationError();
-        validationError.setMessage(exception.getMessage());
-        validationError.setRuleName("XSD validation");
+        var xsdMessage = exception.getMessage();
+        validationError.setMessage(getMessage(xsdMessage));
+        validationError.setRuleName(getRuleName(xsdMessage));
         validationError.setLinenumber(exception.getLineNumber());
         validationError.setColumnNumber(exception.getColumnNumber());
         return validationError;
+    }
+
+    String getRuleName(String xsdMessage) {
+        var ruleName = DEFAULT_RULE_NAME;
+        if (xsdMessage != null && !xsdMessage.isBlank()) {
+            int endIndex = xsdMessage.indexOf(':');
+            if (endIndex > 0) {
+                var tmpRuleName = xsdMessage.substring(0, endIndex);
+                if (!tmpRuleName.contains(" ")) {
+                    ruleName = "XSD/" + tmpRuleName;
+                }
+            }
+        }
+        return ruleName;
+    }
+
+    String getMessage(String xsdMessage) {
+        var message = xsdMessage;
+        if (message != null && !message.isBlank()) {
+            int endIndex = message.indexOf(':');
+            if (endIndex > 0) {
+                var tmpRuleName = xsdMessage.substring(0, endIndex);
+                if (!tmpRuleName.contains(" ")) {
+                    message = message.substring(endIndex + 1).trim();
+                }
+            }
+        }
+        return message;
     }
 }

--- a/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDValidator.java
+++ b/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDValidator.java
@@ -49,35 +49,17 @@ public class XSDValidator {
         validator.setErrorHandler(new ErrorHandler() {
             @Override
             public void warning(SAXParseException exception) {
-                var validationError = createValidationError(exception);
-                errorList.add(validationError);
-
-                LOGGER.debug("XSD Validation - warning: '{}' (Linenumber {}, Columnnumber {})",
-                        validationError.getMessage(),
-                        validationError.getLinenumber(),
-                        validationError.getColumnNumber());
+                errorList.add(createValidationError(exception, "warning"));
             }
 
             @Override
             public void error(SAXParseException exception) {
-                var validationError = createValidationError(exception);
-                errorList.add(validationError);
-
-                LOGGER.debug("XSD Validation - error: '{}' (Linenumber {}, Columnnumber {})",
-                        validationError.getMessage(),
-                        validationError.getLinenumber(),
-                        validationError.getColumnNumber());
+                errorList.add(createValidationError(exception, "error"));
             }
 
             @Override
             public void fatalError(SAXParseException exception) {
-                var validationError = createValidationError(exception);
-                errorList.add(validationError);
-
-                LOGGER.debug("XSD Validation - fatal error, stopping: '{}' (Linenumber {}, Columnnumber {})",
-                        validationError.getMessage(),
-                        validationError.getLinenumber(),
-                        validationError.getColumnNumber());
+                errorList.add(createValidationError(exception, "fatal"));
             }
         });
     }
@@ -93,12 +75,19 @@ public class XSDValidator {
         }
     }
 
-    private ValidationError createValidationError(SAXParseException exception) {
+    private ValidationError createValidationError(SAXParseException exception, String type) {
         var validationError = new ValidationError();
         validationError.setMessage(exception.getMessage());
         validationError.setRuleName("XSD validation");
         validationError.setLinenumber(exception.getLineNumber());
         validationError.setColumnNumber(exception.getColumnNumber());
+
+        LOGGER.debug("XSD Validation - {}: '{}' (Linenumber {}, Columnnumber {})",
+                type,
+                validationError.getMessage(),
+                validationError.getLinenumber(),
+                validationError.getColumnNumber());
+
         return validationError;
     }
 }

--- a/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDValidator.java
+++ b/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDValidator.java
@@ -80,7 +80,7 @@ public class XSDValidator {
         validationError.setLinenumber(exception.getLineNumber());
         validationError.setColumnNumber(exception.getColumnNumber());
 
-        LOGGER.debug("XSD Validation - {}: '{}' (Linenumber {}, Columnnumber {})",
+        LOGGER.debug("XSD Validation - {}: '{}' (Linenumber {}, Column number {})",
                 type,
                 validationError.getMessage(),
                 validationError.getLinenumber(),

--- a/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDValidator.java
+++ b/validator/src/main/java/org/lfenergy/compas/scl/validator/xsd/XSDValidator.java
@@ -68,10 +68,8 @@ public class XSDValidator {
         try {
             SAXSource source = new SAXSource(new InputSource(new StringReader(sclData)));
             validator.validate(source);
-        } catch (IOException exception) {
-            LOGGER.error("[XSD validation] IOException: {}", exception.getMessage());
-        } catch (SAXException exception) {
-            LOGGER.error("[XSD validation] SAXException: {}", exception.getMessage());
+        } catch (IOException | SAXException exception) {
+            LOGGER.error("[XSD validation] Exception: {}", exception.getMessage());
         }
     }
 

--- a/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
+++ b/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Alliander N.V.
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.validator.xsd;
 
 import org.junit.jupiter.api.Test;

--- a/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
+++ b/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.lfenergy.compas.scl.validator.xsd.XSDErrorHandler.DEFAULT_PREFIX;
 import static org.lfenergy.compas.scl.validator.xsd.XSDErrorHandler.DEFAULT_RULE_NAME;
 
@@ -63,31 +62,27 @@ class XSDErrorHandlerTest {
 
     @Test
     void getRuleName_WhenXSDMessageIsNull_ThenDefaultXSDRuleNameReturned() {
-        var ruleName = handler.getRuleName(null);
-
-        assertEquals(DEFAULT_RULE_NAME, ruleName);
+        executeTest_getRuleName_WhereResultIsDefaultRuleName(null);
     }
 
     @Test
     void getRuleName_WhenXSDMessageIsBlank_ThenDefaultXSDRuleNameReturned() {
-        var ruleName = handler.getRuleName("");
-
-        assertEquals(DEFAULT_RULE_NAME, ruleName);
+        executeTest_getRuleName_WhereResultIsDefaultRuleName("");
     }
 
     @Test
     void getRuleName_WhenXSDMessageContainsNoRule_ThenDefaultXSDRuleNameReturned() {
-        var xsdMessage = "Duplicate match in scope for field \"depth\"";
-
-        var ruleName = handler.getRuleName(xsdMessage);
-
-        assertEquals(DEFAULT_RULE_NAME, ruleName);
+        executeTest_getRuleName_WhereResultIsDefaultRuleName(
+                "Duplicate match in scope for field \"depth\"");
     }
 
     @Test
     void getRuleName_WhenXSDMessageContainsRuleWithSpaces_ThenDefaultXSDRuleNameReturned() {
-        var xsdMessage = "SOME SPACES RULE: Duplicate match in scope for field \"depth\"";
+        executeTest_getRuleName_WhereResultIsDefaultRuleName(
+                "SOME SPACES RULE: Duplicate match in scope for field \"depth\"");
+    }
 
+    private void executeTest_getRuleName_WhereResultIsDefaultRuleName(String xsdMessage) {
         var ruleName = handler.getRuleName(xsdMessage);
 
         assertEquals(DEFAULT_RULE_NAME, ruleName);
@@ -106,33 +101,25 @@ class XSDErrorHandlerTest {
 
     @Test
     void getMessage_WhenXSDMessageIsNull_ThenNullReturned() {
-        var message = handler.getMessage(null);
-
-        assertNull(message);
+        executeTest_GetMessage_WhereInputIsResult(null);
     }
 
     @Test
     void getMessage_WhenXSDMessageIsBlank_ThenBlankMessageReturned() {
-        var xsdMessage = " ";
-
-        var message = handler.getMessage(xsdMessage);
-
-        assertEquals(xsdMessage, message);
+        executeTest_GetMessage_WhereInputIsResult(" ");
     }
 
     @Test
     void getMessage_WhenXSDMessageContainsNoRule_ThenOriginalMessageReturned() {
-        var xsdMessage = "Duplicate match in scope for field \"depth\"";
-
-        var message = handler.getMessage(xsdMessage);
-
-        assertEquals(xsdMessage, message);
+        executeTest_GetMessage_WhereInputIsResult("Duplicate match in scope for field \"depth\"");
     }
 
     @Test
     void getMessage_WhenXSDMessageContainsRuleWithSpaces_ThenOriginalMessageReturned() {
-        var xsdMessage = "SOME SPACES RULE: Duplicate match in scope for field \"depth\"";
+        executeTest_GetMessage_WhereInputIsResult("SOME SPACES RULE: Duplicate match in scope for field \"depth\"");
+    }
 
+    private void executeTest_GetMessage_WhereInputIsResult(String xsdMessage) {
         var message = handler.getMessage(xsdMessage);
 
         assertEquals(xsdMessage, message);

--- a/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
+++ b/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
@@ -21,42 +21,42 @@ class XSDErrorHandlerTest {
     @Test
     void warning_WhenCalled_ThenNewValidationErrorAddedToList() {
         var message = "Some Warning Message";
-        var linenumber = 3;
+        var lineNumber = 3;
         var columnNumber = 15;
 
-        handler.warning(new SAXParseException(message, "", "", linenumber, columnNumber));
+        handler.warning(new SAXParseException(message, "", "", lineNumber, columnNumber));
 
         assertEquals(1, errorList.size());
-        assertValidationError(errorList.get(0), message, linenumber, columnNumber);
+        assertValidationError(errorList.get(0), message, lineNumber, columnNumber);
     }
 
     @Test
     void error_WhenCalled_ThenNewValidationErrorAddedToList() {
         var message = "Some Error Message";
-        var linenumber = 5;
+        var lineNumber = 5;
         var columnNumber = 25;
 
-        handler.error(new SAXParseException(message, "", "", linenumber, columnNumber));
+        handler.error(new SAXParseException(message, "", "", lineNumber, columnNumber));
 
         assertEquals(1, errorList.size());
-        assertValidationError(errorList.get(0), message, linenumber, columnNumber);
+        assertValidationError(errorList.get(0), message, lineNumber, columnNumber);
     }
 
     @Test
     void fatalError_WhenCalled_ThenNewValidationErrorAddedToList() {
         var message = "Some Error Message";
-        var linenumber = 5;
+        var lineNumber = 5;
         var columnNumber = 25;
 
-        handler.fatalError(new SAXParseException(message, "", "", linenumber, columnNumber));
+        handler.fatalError(new SAXParseException(message, "", "", lineNumber, columnNumber));
 
         assertEquals(1, errorList.size());
-        assertValidationError(errorList.get(0), message, linenumber, columnNumber);
+        assertValidationError(errorList.get(0), message, lineNumber, columnNumber);
     }
 
-    private void assertValidationError(ValidationError validationError, String message, int linenumber, int columnNumber) {
+    private void assertValidationError(ValidationError validationError, String message, int lineNumber, int columnNumber) {
         assertEquals(message, validationError.getMessage());
-        assertEquals(linenumber, validationError.getLinenumber());
+        assertEquals(lineNumber, validationError.getLineNumber());
         assertEquals(columnNumber, validationError.getColumnNumber());
     }
 

--- a/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
+++ b/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
@@ -1,0 +1,57 @@
+package org.lfenergy.compas.scl.validator.xsd;
+
+import org.junit.jupiter.api.Test;
+import org.lfenergy.compas.scl.validator.model.ValidationError;
+import org.xml.sax.SAXParseException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class XSDErrorHandlerTest {
+    private List<ValidationError> errorList = new ArrayList<>();
+    private XSDErrorHandler handler = new XSDErrorHandler(errorList);
+
+    @Test
+    void warning_WhenCalled_ThenNewValidationErrorAddedToList() {
+        var message = "Some Warning Message";
+        var linenumber = 3;
+        var columnNumber = 15;
+
+        handler.warning(new SAXParseException(message, "", "", linenumber, columnNumber));
+
+        assertEquals(1, errorList.size());
+        assertValidationError(errorList.get(0), message, linenumber, columnNumber);
+    }
+
+    @Test
+    void error_WhenCalled_ThenNewValidationErrorAddedToList() {
+        var message = "Some Error Message";
+        var linenumber = 5;
+        var columnNumber = 25;
+
+        handler.error(new SAXParseException(message, "", "", linenumber, columnNumber));
+
+        assertEquals(1, errorList.size());
+        assertValidationError(errorList.get(0), message, linenumber, columnNumber);
+    }
+
+    @Test
+    void fatalError_WhenCalled_ThenNewValidationErrorAddedToList() {
+        var message = "Some Error Message";
+        var linenumber = 5;
+        var columnNumber = 25;
+
+        handler.fatalError(new SAXParseException(message, "", "", linenumber, columnNumber));
+
+        assertEquals(1, errorList.size());
+        assertValidationError(errorList.get(0), message, linenumber, columnNumber);
+    }
+
+    private void assertValidationError(ValidationError validationError, String message, int linenumber, int columnNumber) {
+        assertEquals(message, validationError.getMessage());
+        assertEquals(linenumber, validationError.getLinenumber());
+        assertEquals(columnNumber, validationError.getColumnNumber());
+    }
+}

--- a/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
+++ b/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.lfenergy.compas.scl.validator.xsd.XSDErrorHandler.DEFAULT_PREFIX;
 import static org.lfenergy.compas.scl.validator.xsd.XSDErrorHandler.DEFAULT_RULE_NAME;
 
@@ -61,6 +62,20 @@ class XSDErrorHandlerTest {
     }
 
     @Test
+    void getRuleName_WhenXSDMessageIsNull_ThenDefaultXSDRuleNameReturned() {
+        var ruleName = handler.getRuleName(null);
+
+        assertEquals(DEFAULT_RULE_NAME, ruleName);
+    }
+
+    @Test
+    void getRuleName_WhenXSDMessageIsBlank_ThenDefaultXSDRuleNameReturned() {
+        var ruleName = handler.getRuleName("");
+
+        assertEquals(DEFAULT_RULE_NAME, ruleName);
+    }
+
+    @Test
     void getRuleName_WhenXSDMessageContainsNoRule_ThenDefaultXSDRuleNameReturned() {
         var xsdMessage = "Duplicate match in scope for field \"depth\"";
 
@@ -87,6 +102,22 @@ class XSDErrorHandlerTest {
         var ruleName = handler.getRuleName(xsdMessage);
 
         assertEquals(DEFAULT_PREFIX + expectedRuleName, ruleName);
+    }
+
+    @Test
+    void getMessage_WhenXSDMessageIsNull_ThenNullReturned() {
+        var message = handler.getMessage(null);
+
+        assertNull(message);
+    }
+
+    @Test
+    void getMessage_WhenXSDMessageIsBlank_ThenBlankMessageReturned() {
+        var xsdMessage = " ";
+
+        var message = handler.getMessage(xsdMessage);
+
+        assertEquals(xsdMessage, message);
     }
 
     @Test

--- a/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
+++ b/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDErrorHandlerTest.java
@@ -11,6 +11,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.lfenergy.compas.scl.validator.xsd.XSDErrorHandler.DEFAULT_PREFIX;
+import static org.lfenergy.compas.scl.validator.xsd.XSDErrorHandler.DEFAULT_RULE_NAME;
 
 class XSDErrorHandlerTest {
     private List<ValidationError> errorList = new ArrayList<>();
@@ -56,5 +58,63 @@ class XSDErrorHandlerTest {
         assertEquals(message, validationError.getMessage());
         assertEquals(linenumber, validationError.getLinenumber());
         assertEquals(columnNumber, validationError.getColumnNumber());
+    }
+
+    @Test
+    void getRuleName_WhenXSDMessageContainsNoRule_ThenDefaultXSDRuleNameReturned() {
+        var xsdMessage = "Duplicate match in scope for field \"depth\"";
+
+        var ruleName = handler.getRuleName(xsdMessage);
+
+        assertEquals(DEFAULT_RULE_NAME, ruleName);
+    }
+
+    @Test
+    void getRuleName_WhenXSDMessageContainsRuleWithSpaces_ThenDefaultXSDRuleNameReturned() {
+        var xsdMessage = "SOME SPACES RULE: Duplicate match in scope for field \"depth\"";
+
+        var ruleName = handler.getRuleName(xsdMessage);
+
+        assertEquals(DEFAULT_RULE_NAME, ruleName);
+    }
+
+    @Test
+    void getRuleName_WhenXSDMessageContainsRule_ThenRuleNameReturned() {
+        var expectedRuleName = "cvc-complex-type.2.1";
+        var xsdMessage = expectedRuleName + ": Element 'depth' must have no character or element information " +
+                "item [children], because the type's content type is empty.";
+
+        var ruleName = handler.getRuleName(xsdMessage);
+
+        assertEquals(DEFAULT_PREFIX + expectedRuleName, ruleName);
+    }
+
+    @Test
+    void getMessage_WhenXSDMessageContainsNoRule_ThenOriginalMessageReturned() {
+        var xsdMessage = "Duplicate match in scope for field \"depth\"";
+
+        var message = handler.getMessage(xsdMessage);
+
+        assertEquals(xsdMessage, message);
+    }
+
+    @Test
+    void getMessage_WhenXSDMessageContainsRuleWithSpaces_ThenOriginalMessageReturned() {
+        var xsdMessage = "SOME SPACES RULE: Duplicate match in scope for field \"depth\"";
+
+        var message = handler.getMessage(xsdMessage);
+
+        assertEquals(xsdMessage, message);
+    }
+
+    @Test
+    void getMessage_WhenXSDMessageContainsRule_ThenRuleNameIsStrippedFromMessage() {
+        var ruleName = "cvc-complex-type.2.1";
+        var expectedMessage = "Element 'depth' must have no character or element information item [children], " +
+                "because the type's content type is empty.";
+
+        var message = handler.getMessage(ruleName + ": " + expectedMessage);
+
+        assertEquals(expectedMessage, message);
     }
 }

--- a/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDValidatorTest.java
+++ b/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDValidatorTest.java
@@ -39,8 +39,8 @@ class XSDValidatorTest {
             assertEquals(4, errorList.size());
 
             var error = errorList.get(2);
-            assertEquals("cvc-complex-type.4: Attribute 'name' must appear on element 'BDA'.", error.getMessage());
-            assertEquals("XSD validation", error.getRuleName());
+            assertEquals("Attribute 'name' must appear on element 'BDA'.", error.getMessage());
+            assertEquals("XSD/cvc-complex-type.4", error.getRuleName());
             assertEquals(66, error.getLinenumber());
             assertEquals(45, error.getColumnNumber());
         }

--- a/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDValidatorTest.java
+++ b/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDValidatorTest.java
@@ -11,7 +11,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.lfenergy.compas.scl.validator.exception.SclValidatorErrorCode.LOADING_XSD_FILE_ERROR_CODE;
 
 class XSDValidatorTest {
@@ -38,8 +39,10 @@ class XSDValidatorTest {
             assertEquals(4, errorList.size());
 
             var error = errorList.get(2);
-            assertEquals("[XSD validation] (line: 66, column: 45): cvc-complex-type.4: " +
-                    "Attribute 'name' must appear on element 'BDA'.",error.getMessage());
+            assertEquals("cvc-complex-type.4: Attribute 'name' must appear on element 'BDA'.", error.getMessage());
+            assertEquals("XSD validation", error.getRuleName());
+            assertEquals(66, error.getLinenumber());
+            assertEquals(45, error.getColumnNumber());
         }
     }
 

--- a/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDValidatorTest.java
+++ b/validator/src/test/java/org/lfenergy/compas/scl/validator/xsd/XSDValidatorTest.java
@@ -41,7 +41,7 @@ class XSDValidatorTest {
             var error = errorList.get(2);
             assertEquals("Attribute 'name' must appear on element 'BDA'.", error.getMessage());
             assertEquals("XSD/cvc-complex-type.4", error.getRuleName());
-            assertEquals(66, error.getLinenumber());
+            assertEquals(66, error.getLineNumber());
             assertEquals(45, error.getColumnNumber());
         }
     }


### PR DESCRIPTION
closes #106 

Beside processing the XSD Message by splitting the parts.
Also added the Column number and changed Line number (CamelCase).
And when processing the XSD Message checked if the message starts with a code, that will be set as RuleName.
Only try to extract the code from the message when the first part until the character ":" doesn't contain any spaces.