### PR TITLE
Fixed missing StaX Parser (Woodstox)

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -55,6 +55,11 @@ SPDX-License-Identifier: Apache-2.0
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-websockets</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt</artifactId>
         </dependency>
         <dependency>
@@ -65,17 +70,14 @@ SPDX-License-Identifier: Apache-2.0
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-websockets</artifactId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-container-image-docker</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/event/SclValidatorEventRequest.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/event/SclValidatorEventRequest.java
@@ -12,10 +12,6 @@ public class SclValidatorEventRequest {
     private final SclFileType type;
     private final String sclData;
 
-    public SclValidatorEventRequest(SclFileType type, String sclData) {
-        this(null, type, sclData);
-    }
-
     public SclValidatorEventRequest(Session session, SclFileType type, String sclData) {
         this.session = session;
         this.type = type;

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/SclValidatorResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/SclValidatorResourceTest.java
@@ -34,7 +34,7 @@ class SclValidatorResourceTest {
     private SclValidatorService sclValidatorService;
 
     @Test
-    void updateSCL_WhenCalled_ThenExpectedResponseIsRetrieved() throws IOException {
+    void validate_WhenCalled_ThenExpectedResponseIsRetrieved() throws IOException {
         var sclFileTye = SclFileType.CID;
         var request = new SclValidateRequest();
         request.setSclData(TestSupportUtil.readSCL("scl-1.scd"));

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/SclValidatorServerEndpointTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/SclValidatorServerEndpointTest.java
@@ -42,7 +42,7 @@ class SclValidatorServerEndpointTest {
     private URI uri;
 
     @Test
-    void updateSCL_WhenCalled_ThenExpectedResponseIsRetrieved() throws Exception {
+    void validate_WhenCalled_ThenExpectedResponseIsRetrieved() throws Exception {
         var encoder = new SclValidateRequestEncoder();
         var sclFileTye = SclFileType.SCD;
         var request = new SclValidateRequest();

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/event/SclValidatorEventHandlerTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/event/SclValidatorEventHandlerTest.java
@@ -17,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.websocket.RemoteEndpoint;
 import javax.websocket.Session;
-import java.io.IOException;
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,7 +31,7 @@ class SclValidatorEventHandlerTest {
     private SclValidatorEventHandler eventHandler;
 
     @Test
-    void validateWebsocketsEvent_WhenCalled_ThenExpectedCallsAreMade() throws IOException {
+    void validateWebsocketsEvent_WhenCalled_ThenExpectedCallsAreMade() {
         var veList = new ArrayList<ValidationError>();
         var type = SclFileType.CID;
         var sclData = "Some SCL Data";

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/event/SclValidatorEventRequestTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/rest/v1/event/SclValidatorEventRequestTest.java
@@ -14,21 +14,8 @@ import org.mockito.Mockito;
 import javax.websocket.Session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 class SclValidatorEventRequestTest {
-    @Test
-    void constructor_WhenCalledWith2Arguments_ThenValuesSet() {
-        var type = SclFileType.CID;
-        var sclData = "Some SCL Data";
-
-        var result = new SclValidatorEventRequest(type, sclData);
-
-        assertNull(result.getSession());
-        assertEquals(type, result.getType());
-        assertEquals(sclData, result.getSclData());
-    }
-
     @Test
     void constructor_WhenCalledWith3Arguments_ThenValuesSet() {
         var session = Mockito.mock(Session.class);
@@ -46,9 +33,9 @@ class SclValidatorEventRequestTest {
     void validateSettersAndGetters() {
         var personPojo = PojoClassFactory.getPojoClass(SclValidatorEventRequest.class);
         var validator = ValidatorBuilder.create()
-                // Lets make sure that we have a getter for every field defined.
+                // Let's make sure that we have a getter for every field defined.
                 .with(new GetterMustExistRule())
-                // Lets also validate that they are behaving as expected
+                // Let's also validate that they are behaving as expected
                 .with(new GetterTester())
                 .build();
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@ SPDX-License-Identifier: Apache-2.0
                 <artifactId>xercesImpl</artifactId>
                 <version>2.12.2</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>6.4.0</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.openapi</groupId>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -44,6 +44,10 @@ SPDX-License-Identifier: Apache-2.0
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Main solution was adding the WoodStoX dependency to the POM files.

But also some small improvements found during build Websockets for Data Service.
These where already there and aren't breaking anything.