### PR TITLE
fix: check for correct OS name

### DIFF
--- a/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/impl/OclFileLoaderTest.java
+++ b/riseclipse/validator-riseclipse/src/test/java/org/lfenergy/compas/scl/validator/impl/OclFileLoaderTest.java
@@ -74,7 +74,7 @@ class OclFileLoaderTest {
     }
 
     private boolean isWindows() {
-        return System.getProperty("os.name").contains("win");
+        return System.getProperty("os.name").toLowerCase().contains("win");
     }
 
     @Test


### PR DESCRIPTION
Windows 11 has as os.name "Windows NT", therefor needed a ignoreCase

Signed-off-by: Stef3st <steffen.van.den.driest@alliander.com>