### PR TITLE
Upgrade to Quarkus 3.0

### DIFF
--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/CompasSclValidatorConfiguration.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/CompasSclValidatorConfiguration.java
@@ -11,8 +11,8 @@ import org.lfenergy.compas.scl.validator.collector.OclFileCollector;
 import org.lfenergy.compas.scl.validator.common.NsdocFinder;
 import org.lfenergy.compas.scl.validator.impl.SclRiseClipseValidator;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
 
 /**
  * Create Beans from other dependencies that are used in the application.

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/exception/NsdocNotFoundExceptionHandler.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/exception/NsdocNotFoundExceptionHandler.java
@@ -6,9 +6,9 @@ package org.lfenergy.compas.scl.validator.rest.exception;
 import org.lfenergy.compas.core.commons.model.ErrorResponse;
 import org.lfenergy.compas.scl.validator.exception.NsdocFileNotFoundException;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class NsdocNotFoundExceptionHandler implements ExceptionMapper<NsdocFileNotFoundException> {

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/monitoring/LivenessHealthCheck.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/monitoring/LivenessHealthCheck.java
@@ -7,7 +7,7 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @Liveness
 @ApplicationScoped

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/monitoring/ReadinessHealthCheck.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/monitoring/ReadinessHealthCheck.java
@@ -7,7 +7,7 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @Readiness
 @ApplicationScoped

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/NsdocResource.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/NsdocResource.java
@@ -11,9 +11,9 @@ import org.lfenergy.compas.scl.validator.rest.v1.model.NsdocListResponse;
 import org.lfenergy.compas.scl.validator.rest.v1.model.NsdocResponse;
 import org.lfenergy.compas.scl.validator.service.NsdocService;
 
-import javax.enterprise.context.RequestScoped;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 import java.util.UUID;
 
 import static org.lfenergy.compas.scl.validator.rest.SclResourceConstants.ID_PARAM;

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/SclValidatorResource.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/SclValidatorResource.java
@@ -12,11 +12,11 @@ import org.lfenergy.compas.scl.validator.rest.v1.model.SclValidateRequest;
 import org.lfenergy.compas.scl.validator.rest.v1.model.SclValidateResponse;
 import org.lfenergy.compas.scl.validator.service.SclValidatorService;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.validation.Valid;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 
 import static org.lfenergy.compas.scl.validator.rest.SclResourceConstants.TYPE_PATH_PARAM;
 

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/model/NsdocListResponse.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/model/NsdocListResponse.java
@@ -6,10 +6,10 @@ package org.lfenergy.compas.scl.validator.rest.v1.model;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.lfenergy.compas.scl.validator.model.NsdocFile;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Collection;
 
 import static org.lfenergy.compas.scl.validator.SclValidatorConstants.SCL_VALIDATOR_SERVICE_V1_NS_URI;

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/model/NsdocResponse.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/model/NsdocResponse.java
@@ -5,10 +5,10 @@ package org.lfenergy.compas.scl.validator.rest.v1.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static org.lfenergy.compas.scl.validator.SclValidatorConstants.SCL_VALIDATOR_SERVICE_V1_NS_URI;
 

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/model/SclValidateRequest.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/model/SclValidateRequest.java
@@ -6,11 +6,11 @@ package org.lfenergy.compas.scl.validator.rest.v1.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-import javax.validation.constraints.NotBlank;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static org.lfenergy.compas.scl.validator.SclValidatorConstants.SCL_VALIDATOR_SERVICE_V1_NS_URI;
 

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/model/SclValidateResponse.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/model/SclValidateResponse.java
@@ -6,10 +6,10 @@ package org.lfenergy.compas.scl.validator.rest.v1.model;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.lfenergy.compas.scl.validator.model.ValidationError;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
 import static org.lfenergy.compas.scl.validator.SclValidatorConstants.SCL_VALIDATOR_SERVICE_V1_NS_URI;

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/model/package-info.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/rest/v1/model/package-info.java
@@ -8,7 +8,7 @@
 )
 package org.lfenergy.compas.scl.validator.rest.v1.model;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;
 
 import static org.lfenergy.compas.scl.validator.SclValidatorConstants.SCL_VALIDATOR_SERVICE_V1_NS_URI;

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/websocket/event/SclValidatorEventHandler.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/websocket/event/SclValidatorEventHandler.java
@@ -9,8 +9,8 @@ import org.lfenergy.compas.scl.validator.service.SclValidatorService;
 import org.lfenergy.compas.scl.validator.websocket.event.model.SclValidatorEventRequest;
 import org.lfenergy.compas.scl.validator.websocket.v1.model.SclValidateWsResponse;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * Event Handler used to execute the validation asynchronized.

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/websocket/event/model/SclValidatorEventRequest.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/websocket/event/model/SclValidatorEventRequest.java
@@ -5,7 +5,7 @@ package org.lfenergy.compas.scl.validator.websocket.event.model;
 
 import org.lfenergy.compas.scl.extensions.model.SclFileType;
 
-import javax.websocket.Session;
+import jakarta.websocket.Session;
 
 public class SclValidatorEventRequest {
     private Session session;

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/websocket/v1/SclValidatorServerEndpoint.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/websocket/v1/SclValidatorServerEndpoint.java
@@ -14,12 +14,12 @@ import org.lfenergy.compas.scl.validator.websocket.v1.decoder.SclValidateWsReque
 import org.lfenergy.compas.scl.validator.websocket.v1.encoder.SclValidateWsResponseEncoder;
 import org.lfenergy.compas.scl.validator.websocket.v1.model.SclValidateWsRequest;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.validation.Valid;
-import javax.websocket.*;
-import javax.websocket.server.PathParam;
-import javax.websocket.server.ServerEndpoint;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.websocket.*;
+import jakarta.websocket.server.PathParam;
+import jakarta.websocket.server.ServerEndpoint;
 
 import static org.lfenergy.compas.core.websocket.WebsocketSupport.handleException;
 import static org.lfenergy.compas.scl.validator.rest.SclResourceConstants.TYPE_PATH_PARAM;

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/websocket/v1/model/SclValidateWsRequest.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/websocket/v1/model/SclValidateWsRequest.java
@@ -7,10 +7,10 @@ package org.lfenergy.compas.scl.validator.websocket.v1.model;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.lfenergy.compas.scl.validator.rest.v1.model.SclValidateRequest;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 import static org.lfenergy.compas.scl.validator.SclValidatorConstants.SCL_VALIDATOR_SERVICE_V1_NS_URI;
 

--- a/app/src/main/java/org/lfenergy/compas/scl/validator/websocket/v1/model/SclValidateWsResponse.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/validator/websocket/v1/model/SclValidateWsResponse.java
@@ -6,10 +6,10 @@ package org.lfenergy.compas.scl.validator.websocket.v1.model;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.lfenergy.compas.scl.validator.rest.v1.model.SclValidateResponse;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 import static org.lfenergy.compas.scl.validator.SclValidatorConstants.SCL_VALIDATOR_SERVICE_V1_NS_URI;
 

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/rest/exception/NsdocNotFoundExceptionHandlerTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/rest/exception/NsdocNotFoundExceptionHandlerTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.lfenergy.compas.core.commons.model.ErrorResponse;
 import org.lfenergy.compas.scl.validator.exception.NsdocFileNotFoundException;
 
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/websocket/event/SclValidatorEventHandlerTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/websocket/event/SclValidatorEventHandlerTest.java
@@ -18,8 +18,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.websocket.RemoteEndpoint;
-import javax.websocket.Session;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.Session;
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/websocket/event/model/SclValidatorEventRequestTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/websocket/event/model/SclValidatorEventRequestTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.lfenergy.compas.scl.extensions.model.SclFileType;
 import org.mockito.Mockito;
 
-import javax.websocket.Session;
+import jakarta.websocket.Session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/websocket/v1/SclValidatorServerEndpointTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/websocket/v1/SclValidatorServerEndpointTest.java
@@ -20,10 +20,10 @@ import org.lfenergy.compas.scl.validator.websocket.v1.encoder.SclValidateWsReque
 import org.lfenergy.compas.scl.validator.websocket.v1.model.SclValidateWsRequest;
 import org.lfenergy.compas.scl.validator.websocket.v1.model.SclValidateWsResponse;
 
-import javax.websocket.ClientEndpoint;
-import javax.websocket.ContainerProvider;
-import javax.websocket.OnMessage;
-import javax.websocket.Session;
+import jakarta.websocket.ClientEndpoint;
+import jakarta.websocket.ContainerProvider;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.Session;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingDeque;

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/websocket/v1/decoder/SclValidateWsRequestDecoderTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/websocket/v1/decoder/SclValidateWsRequestDecoderTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.lfenergy.compas.core.commons.exception.CompasException;
 
-import javax.xml.bind.UnmarshalException;
+import jakarta.xml.bind.UnmarshalException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.WEBSOCKET_DECODER_ERROR_CODE;

--- a/app/src/test/java/org/lfenergy/compas/scl/validator/websocket/v1/decoder/SclValidateWsResponseDecoderTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/validator/websocket/v1/decoder/SclValidateWsResponseDecoderTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.lfenergy.compas.core.commons.exception.CompasException;
 
-import javax.xml.bind.UnmarshalException;
+import jakarta.xml.bind.UnmarshalException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.WEBSOCKET_DECODER_ERROR_CODE;

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: Apache-2.0
         <sonarqube-plugin.version>3.2.0</sonarqube-plugin.version>
 
         <compas.scl.xsd.version>0.0.4</compas.scl.xsd.version>
-        <compas.core.version>local-SNAPSHOT</compas.core.version>
+        <compas.core.version>0.16.0</compas.core.version>
 
         <quarkus.platform.version>3.0.4.Final</quarkus.platform.version>
         <log4j2.version>2.20.0</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@ SPDX-License-Identifier: Apache-2.0
         <sonarqube-plugin.version>3.2.0</sonarqube-plugin.version>
 
         <compas.scl.xsd.version>0.0.4</compas.scl.xsd.version>
-        <compas.core.version>0.12.0</compas.core.version>
+        <compas.core.version>local-SNAPSHOT</compas.core.version>
 
-        <quarkus.platform.version>2.16.5.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.0.4.Final</quarkus.platform.version>
         <log4j2.version>2.20.0</log4j2.version>
         <openpojo.version>0.9.1</openpojo.version>
         <maven.compiler.source>17</maven.compiler.source>
@@ -62,8 +62,8 @@ SPDX-License-Identifier: Apache-2.0
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-universe-bom</artifactId>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/service/src/main/java/org/lfenergy/compas/scl/validator/service/NsdocService.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/validator/service/NsdocService.java
@@ -6,8 +6,8 @@ package org.lfenergy.compas.scl.validator.service;
 import org.lfenergy.compas.scl.validator.common.NsdocFinder;
 import org.lfenergy.compas.scl.validator.model.NsdocFile;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.Collection;
 import java.util.UUID;
 

--- a/service/src/main/java/org/lfenergy/compas/scl/validator/service/SclValidatorService.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/validator/service/SclValidatorService.java
@@ -8,8 +8,8 @@ import org.lfenergy.compas.scl.validator.SclValidator;
 import org.lfenergy.compas.scl.validator.model.ValidationError;
 import org.lfenergy.compas.scl.validator.xsd.SclXsdValidator;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.List;
 
 @ApplicationScoped

--- a/validator/src/main/java/org/lfenergy/compas/scl/validator/model/NsdocFile.java
+++ b/validator/src/main/java/org/lfenergy/compas/scl/validator/model/NsdocFile.java
@@ -5,10 +5,10 @@ package org.lfenergy.compas.scl.validator.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-import javax.validation.constraints.NotBlank;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import java.util.UUID;
 
 import static org.lfenergy.compas.scl.validator.SclValidatorConstants.SCL_VALIDATOR_SERVICE_V1_NS_URI;

--- a/validator/src/main/java/org/lfenergy/compas/scl/validator/model/ValidationError.java
+++ b/validator/src/main/java/org/lfenergy/compas/scl/validator/model/ValidationError.java
@@ -5,9 +5,9 @@ package org.lfenergy.compas.scl.validator.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 import static org.lfenergy.compas.scl.validator.SclValidatorConstants.SCL_VALIDATOR_SERVICE_V1_NS_URI;
 


### PR DESCRIPTION
the main change is migrating from JavaEE to JakartaEE.

- update Quarkus bom from io.quarkus:quarkus-universe-bom to io.quarkus.platform:quarkus-bom as it was deprecated since Quarkus 2.1 https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.1#quarkus-universe-bom-is-deprecated (and it is required to use the Quarkus migration tool)
- deactivated tests CompasOclFileCollectorTest and SclRiseClipseValidatorTest which are failign locally so that I can build locally the whole project and have the Quarkus migration tool working
- launched quarkus `quarkus update --stream=3.0` as mentioned in https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#automatic-update-tool which dealt with a fair part of the migration. Then it remained few little tasks.

fix #204

TO  UPDATE THE version of compas.core when a release is available or use the ${project.version} ?

Note: several tests are failing locally fo rme, both with Quarkus 2 and Quarkus 3. They are the same.

requires https://github.com/com-pas/compas-core/pull/230
