### PR TITLE
Remove apache 2 licence

### DIFF
--- a/app/src/test/data/ocl/Busbar.ocl
+++ b/app/src/test/data/ocl/Busbar.ocl
@@ -1,10 +1,4 @@
 /*
- ** SPDX-FileCopyrightText: 2022 Alliander N.V.
- **
- ** SPDX-License-Identifier: Apache-2.0
- */
-
-/*
 *************************************************************************
 **  Copyright (c) 2016-2021 CentraleSupélec & EDF.
 **  All rights reserved. This program and the accompanying materials

--- a/riseclipse/validator-riseclipse/src/test/data/ocl/Busbar.ocl
+++ b/riseclipse/validator-riseclipse/src/test/data/ocl/Busbar.ocl
@@ -1,10 +1,4 @@
 /*
- ** SPDX-FileCopyrightText: 2022 Alliander N.V.
- **
- ** SPDX-License-Identifier: Apache-2.0
- */
-
-/*
 *************************************************************************
 **  Copyright (c) 2016-2021 CentraleSupélec & EDF.
 **  All rights reserved. This program and the accompanying materials

--- a/riseclipse/validator-riseclipse/src/test/resources/ocl-testfiles/example.ocl
+++ b/riseclipse/validator-riseclipse/src/test/resources/ocl-testfiles/example.ocl
@@ -1,10 +1,4 @@
 /*
- ** SPDX-FileCopyrightText: 2022 Alliander N.V.
- **
- ** SPDX-License-Identifier: Apache-2.0
- */
-
-/*
 *************************************************************************
 **  Copyright (c) 2016-2021 CentraleSupélec & EDF.
 **  All rights reserved. This program and the accompanying materials

--- a/riseclipse/validator-riseclipse/src/test/resources/ocl-testfiles/invalid.ocl
+++ b/riseclipse/validator-riseclipse/src/test/resources/ocl-testfiles/invalid.ocl
@@ -1,10 +1,4 @@
 /*
- ** SPDX-FileCopyrightText: 2022 Alliander N.V.
- **
- ** SPDX-License-Identifier: Apache-2.0
- */
-
-/*
 *************************************************************************
 **  Copyright (c) 2016-2021 CentraleSupélec & EDF.
 **  All rights reserved. This program and the accompanying materials


### PR DESCRIPTION
Needed in order to comply with the LF energy guidelines and to prevent license confusion.